### PR TITLE
Add Jest unit tests for calculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "calculadora",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/script.test.js
+++ b/script.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+beforeEach(() => {
+  document.body.innerHTML = '<p id="res"></p>';
+  const scriptContent = fs.readFileSync(path.resolve(__dirname, 'script.js'), 'utf8');
+  // eval in global scope to load functions
+  eval(scriptContent);
+});
+
+describe('calculator functions', () => {
+  test('insert appends numbers', () => {
+    insert('1');
+    expect(document.getElementById('res').innerHTML).toBe('1');
+    insert('2');
+    expect(document.getElementById('res').innerHTML).toBe('12');
+  });
+
+  test('clean clears display', () => {
+    document.getElementById('res').innerHTML = '123';
+    clean();
+    expect(document.getElementById('res').innerHTML).toBe('');
+  });
+
+  test('back removes last character', () => {
+    document.getElementById('res').innerHTML = '123';
+    back();
+    expect(document.getElementById('res').innerHTML).toBe('12');
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest
- add initial unit tests for calculator script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685027065b8c832fa070b7891a33a39b