### PR TITLE
Fix HTML escape for back button

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             <table>
                 <tr>
                     <td><button class="botao" onclick="clean()" >C</button></td>
-                    <td><button class="botao" onclick="back()" ><</button></td>
+                    <td><button class="botao" onclick="back()" >&lt;</button></td>
                     <td><button class="botao" onclick="insert('/')" >/</button></td>
                     <td><button class="botao" onclick="insert('*')" >*</button></td>
                 </tr>


### PR DESCRIPTION
## Summary
- escape the less-than symbol in the back button label so it renders correctly

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685024c5a560832fba291effb5fcd757